### PR TITLE
fixes header padding error when first column is RightJustified

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Simply define the table columns and `tabular` will parse the right [format speci
 
 Table columns can be defined once and then reused over and over again making it easy to modify column length and heading in one place.  And a subset of columns can be specified during `tabular.Print()` or `tabular.Parse()` calls to modify the table's title without redefining it.
 
-Example (also available in [`example/example.go`](example/example.go):
+Example (also available in [`example/example.go`](example/example.go)):
 
 ```go
 package main

--- a/format_test.go
+++ b/format_test.go
@@ -8,27 +8,37 @@ import (
 
 func TestFormat(t *testing.T) {
 	tab := tabular.New()
+	tab.Col("id", "ID", 6)
 	tab.Col("env", "Environment", 14)
 	tab.Col("cls", "Cluster", 10)
 	tab.Col("svc", "Service", 25)
 	tab.Col("hst", "Database Host", 25)
 	tab.Col("pct", "%CPU", 5)
+	tab["id"].RightJustified = true
 	tab["pct"].RightJustified = true
 
 	tWant := tabular.Table{
-		Header:    "Environment    Cluster    Service                   Database Host              %CPU",
-		SubHeader: "-------------- ---------- ------------------------- ------------------------- -----",
-		Format:    "%-14v %-10v %-25v %-25v %5v\n",
+		Header:    "    ID Environment    Cluster    Service                   Database Host              %CPU",
+		SubHeader: "------ -------------- ---------- ------------------------- ------------------------- -----",
+		Format:    "%6v %-14v %-10v %-25v %-25v %5v\n",
 	}
 
 	// Test Printing
 	want := tWant.Format
-	if got := tab.Print("env", "cls", "svc", "hst", "pct"); got != want {
+	if got := tab.Print("id", "env", "cls", "svc", "hst", "pct"); got != want {
 		t.Errorf("ERROR: tab.Print() failed\n   want: %q\n    got: %q", want, got)
 	}
 
 	// Test Parsing
-	if tGot := tab.Parse("env", "cls", "svc", "hst", "pct"); tGot != tWant {
-		t.Errorf("ERROR: tab.Parse() failed\n   want: %v\n    got: %v", tWant, tGot)
+	if tGot := tab.Parse("id", "env", "cls", "svc", "hst", "pct"); tGot != tWant {
+		if tGot.Header != tWant.Header {
+			t.Errorf("ERROR: tab.Parse() failed\n   want: %v\n    got: %v", tWant.Header, tGot.Header)
+		}
+		if tGot.SubHeader != tWant.SubHeader {
+			t.Errorf("ERROR: tab.Parse() failed\n   want: %v\n    got: %v", tWant.SubHeader, tGot.SubHeader)
+		}
+		if tGot.Format != tWant.Format {
+			t.Errorf("ERROR: tab.Parse() failed\n   want: %v\n    got: %v", tWant.Format, tGot.Format)
+		}
 	}
 }

--- a/tabular.go
+++ b/tabular.go
@@ -78,16 +78,19 @@ func (cl Columns) parse(cols ...string) Table {
 	var header string
 	var subHeader string
 	var format string
+	var space string
 	for _, c := range cols {
-		header = header + " " + fmt.Sprintf(cl[c].f(), cl[c].Name)
-		subHeader = subHeader + " " + fmt.Sprintf(cl[c].f(), r(cl[c].Length))
-		format = format + " " + cl[c].f()
+		cf := cl[c].f()
+		header = header + space + fmt.Sprintf(cf, cl[c].Name)
+		subHeader = subHeader + space + fmt.Sprintf(cf, r(cl[c].Length))
+		format = format + space + cf
+		space = " "
 	}
 
 	return Table{
-		Header:    strings.TrimSpace(header),
-		SubHeader: strings.TrimSpace(subHeader),
-		Format:    strings.TrimSpace(format) + "\n",
+		Header:    header,
+		SubHeader: subHeader,
+		Format:    format + "\n",
 	}
 }
 


### PR DESCRIPTION
Prior to this fix, if the first table column is RightJustified, then `tabular` would loose the left padding on the header.  Now, it works as expected and there is a test for this.